### PR TITLE
Bugfix/fixed fetching non existing blocks

### DIFF
--- a/src/ethereum-block-by-date.js
+++ b/src/ethereum-block-by-date.js
@@ -40,7 +40,7 @@ module.exports = class {
         let difference = date.diff(moment.unix(predictedBlock.timestamp), 'seconds');
         let skip = Math.ceil(difference / (blockTime == 0 ? 1 : blockTime));
         if (skip == 0) skip = difference < 0 ? -1 : 1;
-        let nextPredictedBlock = await this.getBlockWrapper(this.getNextBlock(date, predictedBlock.number, skip));
+        let nextPredictedBlock = await this.getBlockWrapper(await this.getNextBlock(date, predictedBlock.number, skip));
         blockTime = Math.abs(
             (parseInt(predictedBlock.timestamp, 10) - parseInt(nextPredictedBlock.timestamp, 10)) /
             (parseInt(predictedBlock.number, 10) - parseInt(nextPredictedBlock.number, 10))
@@ -62,8 +62,9 @@ module.exports = class {
         return false;
     }
 
-    getNextBlock(date, currentBlock, skip) {
+    async getNextBlock(date, currentBlock, skip) {
         let nextBlock = currentBlock + skip;
+        if (nextBlock > this.latestBlock.number) nextBlock = this.latestBlock.number;
         if (this.checkedBlocks[date.unix()].includes(nextBlock)) return this.getNextBlock(date, currentBlock, (skip < 0 ? --skip : ++skip));
         this.checkedBlocks[date.unix()].push(nextBlock);
         return nextBlock < 1 ? 1 : nextBlock;

--- a/src/ethereum-block-by-date.js
+++ b/src/ethereum-block-by-date.js
@@ -40,7 +40,7 @@ module.exports = class {
         let difference = date.diff(moment.unix(predictedBlock.timestamp), 'seconds');
         let skip = Math.ceil(difference / (blockTime == 0 ? 1 : blockTime));
         if (skip == 0) skip = difference < 0 ? -1 : 1;
-        let nextPredictedBlock = await this.getBlockWrapper(await this.getNextBlock(date, predictedBlock.number, skip));
+        let nextPredictedBlock = await this.getBlockWrapper(this.getNextBlock(date, predictedBlock.number, skip));
         blockTime = Math.abs(
             (parseInt(predictedBlock.timestamp, 10) - parseInt(nextPredictedBlock.timestamp, 10)) /
             (parseInt(predictedBlock.number, 10) - parseInt(nextPredictedBlock.number, 10))
@@ -62,7 +62,7 @@ module.exports = class {
         return false;
     }
 
-    async getNextBlock(date, currentBlock, skip) {
+    getNextBlock(date, currentBlock, skip) {
         let nextBlock = currentBlock + skip;
         if (nextBlock > this.latestBlock.number) nextBlock = this.latestBlock.number;
         if (this.checkedBlocks[date.unix()].includes(nextBlock)) return this.getNextBlock(date, currentBlock, (skip < 0 ? --skip : ++skip));


### PR DESCRIPTION
Fix for this issue -> https://github.com/monosux/ethereum-block-by-date/issues/24
Please review this fix, because on the test network it is trying to fetch future block which does not exist.

Please try this code to reproduce the error.

`import Web3 from 'web3';

const EthDater = require('./src/ethereum-block-by-date');

const provider = new Web3.providers.HttpProvider('https://polygon-mumbai.infura.io/v3/da8d4815fddd422bbd0526ab522495ba');
const web3 = new Web3(provider);
const dater = new EthDater(web3);

async function test() {
    const [blocks] = await Promise.all([dater.getDate('2022-03-27T08:10:59.000Z', true)]);

    console.log('blocks', blocks);
}

test();`