### PR TITLE
feat: get estimated datetime from future block number

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,0 +1,2 @@
+PROVIDER=""
+INFURA_API_KEY=""

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ let requests = dater.requests;
 /* Returns a count of made requests */
 ```
 
-Note: if the given date is before the first block date in the blockchain, the script will return 1 as block number. If the given date is in the future, the script will return the last block number in the blockchain.
+Note: if the given date is before the first block date in the blockchain, the script will return 1 as block number. If the given date is in the future, the script will return the last block number in the blockchain. if the given block is less than the latest block, the script will return the actual timestamp of the given block. If the given block is in the future, the script will return estimated timestamp.
 
 ## Moment.js
 
@@ -162,6 +162,18 @@ let blocks = await dater.getEvery('hours', '2019-10-10T00:00:00Z', '2019-10-11T0
     { date: '2019-10-10T20:00:00Z', block: 8716033, timestamp: 1570737614 },
     { date: '2019-10-11T00:00:00Z', block: 8717086, timestamp: 1570752000 }
 ] */
+```
+
+Get estimate timestamp of future block:
+```javascript
+let futureBlock = 4294967295;
+let timestamp = await dater.getEstimateDate(futureBlock);
+
+/* Returns an object: {
+    date: '3785-06-26T22:32:33Z', // estimated date
+    block: 4294967295, // given block number
+    timestamp: 57291229953 // estimated block timestamp
+*/
 ```
 
 ## Need Help

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Ethereum Block By Date
 
-Get Ethereum block number by a given date. Or blocks by a given period duration.
+Get Ethereum block number by a given date. blocks by a given period duration. or date from a given block
 
 Works with any Ethereum based mainnet or testnet networks.
 

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
 		"moment": "^2.30.1"
 	},
 	"scripts": {
+		"clean": "rimraf lib",
 		"build": "rimraf lib && babel src -d lib",
 		"test": "npm run build && mocha && npm run lint",
 		"lint": "eslint src",

--- a/src/ethereum-block-by-date.js
+++ b/src/ethereum-block-by-date.js
@@ -88,4 +88,18 @@ module.exports = class {
         this.requests++;
         return this.savedBlocks[number];
     }
+
+    async getEstimateDate(block) {
+        if (typeof this.firstBlock == 'undefined' || typeof this.latestBlock == 'undefined' || typeof this.blockTime == 'undefined') {
+            await this.getBoundaries();
+        }
+
+        if (block <= this.latestBlock.number) {
+            block = await this.getBlockWrapper(block);
+            return moment.unix(block.timestamp).utc().format();
+        }
+
+        const estimatedTime = this.latestBlock.timestamp + (block - this.latestBlock.number) * this.blockTime;
+        return moment.unix(estimatedTime).utc().format();
+    }
 };

--- a/src/ethereum-block-by-date.js
+++ b/src/ethereum-block-by-date.js
@@ -95,11 +95,10 @@ module.exports = class {
         }
 
         if (block <= this.latestBlock.number) {
-            block = await this.getBlockWrapper(block);
-            return moment.unix(block.timestamp).utc().format();
+            return await this.getBlockWrapper(block);
+        } else {
+            const estimatedTime = this.latestBlock.timestamp + (block - this.latestBlock.number) * parseInt(this.blockTime);
+            return { date: moment.unix(estimatedTime).utc().format(), block: block, timestamp: estimatedTime };
         }
-
-        const estimatedTime = this.latestBlock.timestamp + (block - this.latestBlock.number) * this.blockTime;
-        return moment.unix(estimatedTime).utc().format();
     }
 };

--- a/src/ethereum-block-by-date.js
+++ b/src/ethereum-block-by-date.js
@@ -10,8 +10,12 @@ module.exports = class {
     }
 
     async getBoundaries() {
-        this.latestBlock = await this.getBlockWrapper('latest');
-        this.firstBlock = await this.getBlockWrapper(1);
+        const [latestBlock, firstBlock] = await Promise.all([
+            this.getBlockWrapper('latest'),
+            this.getBlockWrapper(1)
+        ]);
+        this.latestBlock = latestBlock;
+        this.firstBlock = firstBlock;
         this.blockTime = (parseInt(this.latestBlock.timestamp, 10) - parseInt(this.firstBlock.timestamp, 10)) / (parseInt(this.latestBlock.number, 10) - 1);
     }
 
@@ -97,7 +101,7 @@ module.exports = class {
         if (block <= this.latestBlock.number) {
             return await this.getBlockWrapper(block);
         } else {
-            const estimatedTime = this.latestBlock.timestamp + (block - this.latestBlock.number) * parseInt(this.blockTime);
+            const estimatedTime = this.latestBlock.timestamp + (block - this.latestBlock.number) * this.blockTime;
             return { date: moment.unix(estimatedTime).utc().format(), block: block, timestamp: estimatedTime };
         }
     }

--- a/test/ethers-v5.test.js
+++ b/test/ethers-v5.test.js
@@ -2,26 +2,31 @@ const assert = require('chai').assert;
 const { ethers } = require('ethers-v5');
 const moment = require('moment');
 const ethDater = require('../lib/ethereum-block-by-date');
+require('dotenv').config();
 
-const provider = new ethers.providers.InfuraProvider();
+const provider = new ethers.providers.InfuraProvider('mainnet', process.env.INFURA_API_KEY);
 const dater = new ethDater(provider);
 
-describe('Block By Date Ethers@5 Tests', function() {
-    this.timeout(0);
+const run = async () => {
+    describe('Block By Date Ethers@5 Tests', function () {
+        this.timeout(0);
 
-    it('Should get right block for a given string', async function() {
-        let block = await dater.getDate('2016-07-20T13:20:40Z');
-        assert.equal(block.block, 1920000);
-    });
+        it('Should get right block for a given string', async function () {
+            let block = await dater.getDate('2016-07-20T13:20:40Z');
+            assert.equal(block.block, 1920000);
+        });
 
-    it('Should return 1 as block number if given time is before first block time', async function() {
-        let block = await dater.getDate(new Date('1961-04-12T06:07:00Z'));
-        assert.equal(block.block, 1);
-    });
+        it('Should return 1 as block number if given time is before first block time', async function () {
+            let block = await dater.getDate(new Date('1961-04-12T06:07:00Z'));
+            assert.equal(block.block, 1);
+        });
 
-    it('Should return last block number if given time is in the future', async function() {
-        let last = await provider.getBlockNumber();
-        let block = await dater.getDate(moment().add(100, 'years'), true, true);
-        assert.equal(block.block, last);
+        it('Should return last block number if given time is in the future', async function () {
+            let last = await provider.getBlockNumber();
+            let block = await dater.getDate(moment().add(100, 'years'), true, true);
+            assert.equal(block.block, last);
+        });
     });
-});
+};
+
+module.exports = { run };

--- a/test/ethers.test.js
+++ b/test/ethers.test.js
@@ -3,25 +3,29 @@ const { ethers } = require('ethers');
 const moment = require('moment');
 const ethDater = require('../lib/ethereum-block-by-date');
 
-const provider = new ethers.InfuraProvider();
+const provider = new ethers.InfuraProvider('mainnet', process.env.INFURA_API_KEY);
 const dater = new ethDater(provider);
 
-describe('Block By Date Ethers Tests', function() {
-    this.timeout(0);
+const run = async () => {
+    describe('Block By Date Ethers Tests', function () {
+        this.timeout(0);
 
-    it('Should get right block for a given string', async function() {
-        let block = await dater.getDate('2016-07-20T13:20:40Z');
-        assert.equal(block.block, 1920000);
-    });
+        it('Should get right block for a given string', async function () {
+            let block = await dater.getDate('2016-07-20T13:20:40Z');
+            assert.equal(block.block, 1920000);
+        });
 
-    it('Should return 1 as block number if given time is before first block time', async function() {
-        let block = await dater.getDate(new Date('1961-04-12T06:07:00Z'));
-        assert.equal(block.block, 1);
-    });
+        it('Should return 1 as block number if given time is before first block time', async function () {
+            let block = await dater.getDate(new Date('1961-04-12T06:07:00Z'));
+            assert.equal(block.block, 1);
+        });
 
-    it('Should return last block number if given time is in the future', async function() {
-        let last = await provider.getBlockNumber();
-        let block = await dater.getDate(moment().add(100, 'years'), true, true);
-        assert.equal(block.block, last);
+        it('Should return last block number if given time is in the future', async function () {
+            let last = await provider.getBlockNumber();
+            let block = await dater.getDate(moment().add(100, 'years'), true, true);
+            assert.equal(block.block, last);
+        });
     });
-});
+};
+
+module.exports = { run };

--- a/test/general.test.js
+++ b/test/general.test.js
@@ -95,16 +95,23 @@ const run = async () => {
             let block = await dater.getDate(moment().add(100, 'years'), true, true);
             assert.equal(block.timestamp, timestamp);
         });
-        
-        it('Should return the right estimate timestamp if given block is in the future', async function () {
-            // let { timestamp } = await web3.eth.getBlock('latest');
-            // latest + overheadBlock = futureBlock
-            // calculated estimate date
-            let timestamp = await dater.getEstimateDate(20669502);
-            console.log("timestamp:", timestamp);
-            // let the block passing
-            // check diff between actual and estimate date
-            // assert.equal(block.timestamp, timestamp);
+
+        it('Should return right estimate timestamp if given block is in the future', async function () {
+            const { number } = await web3.eth.getBlock('latest');
+            const block = parseInt(number) + 2;
+            const estimatedDate = moment(await dater.getEstimateDate(block).date);
+            let futureBlock;
+            while (!futureBlock) {
+                try {
+                    futureBlock = await web3.eth.getBlock(block);
+                } catch (error) {
+                    await new Promise(resolve => setTimeout(resolve, 5000));
+                }
+            }
+            const actualDate = moment.unix(parseInt(futureBlock.timestamp)).utc();
+            const diffDate = Math.abs(estimatedDate.diff(actualDate, 'seconds'));
+            // current estimate are not perfect. should be low 15
+            assert.isBelow(diffDate, 20);
         });
     });
 };

--- a/test/general.test.js
+++ b/test/general.test.js
@@ -7,90 +7,106 @@ require('dotenv').config();
 const web3 = new Web3(new Web3.providers.HttpProvider(process.env.PROVIDER));
 const dater = new ethDater(web3);
 
-describe('Block By Date General Tests', function() {
-    this.timeout(0);
+const run = async () => {
+    describe('Block By Date General Tests', function () {
+        this.timeout(0);
 
-    it('Should get right block for a given string', async function() {
-        let block = await dater.getDate('2016-07-20T13:20:40Z');
-        assert.equal(block.block, 1920000);
-    });
+        it('Should get right block for a given string', async function () {
+            let block = await dater.getDate('2016-07-20T13:20:40Z');
+            assert.equal(block.block, 1920000);
+        });
 
-    it('Should get right block for Date object', async function() {
-        let block = await dater.getDate(new Date('2016-07-20T13:20:40Z'));
-        assert.equal(block.block, 1920000);
-    });
+        it('Should get right block for Date object', async function () {
+            let block = await dater.getDate(new Date('2016-07-20T13:20:40Z'));
+            assert.equal(block.block, 1920000);
+        });
 
-    it('Should get right block for Moment object', async function() {
-        let block = await dater.getDate(moment(new Date('2016-07-20T13:20:40Z')).utc());
-        assert.equal(block.block, 1920000);
-    });
+        it('Should get right block for Moment object', async function () {
+            let block = await dater.getDate(moment(new Date('2016-07-20T13:20:40Z')).utc());
+            assert.equal(block.block, 1920000);
+        });
 
-    it('Should get right block for miliseconds', async function() {
-        let block = await dater.getDate(1469020840000);
-        assert.equal(block.block, 1920000);
-    });
+        it('Should get right block for miliseconds', async function () {
+            let block = await dater.getDate(1469020840000);
+            assert.equal(block.block, 1920000);
+        });
 
-    it('Should get previous block for a given string', async function() {
-        let block = await dater.getDate('2016-07-20T13:20:40Z', false);
-        assert.equal(block.block, 1919999);
-    });
+        it('Should get previous block for a given string', async function () {
+            let block = await dater.getDate('2016-07-20T13:20:40Z', false);
+            assert.equal(block.block, 1919999);
+        });
 
-    it('Should get first blocks of the years', async function() {
-        let blocks = await dater.getEvery('years', '2017-01-01T00:00:00Z', '2019-01-01T00:00:00Z');
-        let numbers = blocks.map(block => block.block);
-        let expected = [2912407, 4832686, 6988615];
-        assert.deepEqual(expected, numbers);
-    });
+        it('Should get first blocks of the years', async function () {
+            let blocks = await dater.getEvery('years', '2017-01-01T00:00:00Z', '2019-01-01T00:00:00Z');
+            let numbers = blocks.map(block => block.block);
+            let expected = [2912407, 4832686, 6988615];
+            assert.deepEqual(expected, numbers);
+        });
 
-    it('Should get last blocks of the years', async function() {
-        let blocks = await dater.getEvery('years', '2017-01-01T00:00:00Z', '2019-01-01T00:00:00Z', 1, false);
-        let numbers = blocks.map(block => block.block);
-        let expected = [2912406, 4832685, 6988614];
-        assert.deepEqual(expected, numbers);
-    });
+        it('Should get last blocks of the years', async function () {
+            let blocks = await dater.getEvery('years', '2017-01-01T00:00:00Z', '2019-01-01T00:00:00Z', 1, false);
+            let numbers = blocks.map(block => block.block);
+            let expected = [2912406, 4832685, 6988614];
+            assert.deepEqual(expected, numbers);
+        });
 
-    it('Should return 1 as block number if given time is before first block time', async function() {
-        let block = await dater.getDate(new Date('1961-04-12T06:07:00Z'));
-        assert.equal(block.block, 1);
-    });
+        it('Should return 1 as block number if given time is before first block time', async function () {
+            let block = await dater.getDate(new Date('1961-04-12T06:07:00Z'));
+            assert.equal(block.block, 1);
+        });
 
-    it('Should return last block number if given time is in the future', async function() {
-        let last = await web3.eth.getBlockNumber();
-        let block = await dater.getDate(moment().add(100, 'years'), true, true);
-        assert.equal(block.block, last);
-    });
+        it('Should return last block number if given time is in the future', async function () {
+            let last = await web3.eth.getBlockNumber();
+            let block = await dater.getDate(moment().add(100, 'years'), true, true);
+            assert.equal(block.block, last);
+        });
 
-    it('Should return last block number if given time is bigger than last block timestamp', async function() {
-        let last = await web3.eth.getBlockNumber();
-        let { timestamp } = await web3.eth.getBlock(last);
-        let block = await dater.getDate((Number(timestamp) + 1) * 1000, true, true);
-        assert.equal(block.block, last);
-    });
+        it('Should return last block number if given time is bigger than last block timestamp', async function () {
+            let last = await web3.eth.getBlockNumber();
+            let { timestamp } = await web3.eth.getBlock(last);
+            let block = await dater.getDate((Number(timestamp) + 1) * 1000, true, true);
+            assert.equal(block.block, last);
+        });
 
-    it('Should return unique blocks for hourly request', async function() {
-        let time = moment(),results = [];
-        for (let i = 0; i < 10; i++) {
-            let request = await dater.getDate(time);
-            time.subtract(1, 'hours');
-            results.push(request.block);
-        }
-        let unique = results.filter((v, i, a) => a.indexOf(v) === i);
-        assert.deepEqual(results, unique);
-    });
+        it('Should return unique blocks for hourly request', async function () {
+            let time = moment(),
+                results = [];
+            for (let i = 0; i < 10; i++) {
+                let request = await dater.getDate(time);
+                time.subtract(1, 'hours');
+                results.push(request.block);
+            }
+            let unique = results.filter((v, i, a) => a.indexOf(v) === i);
+            assert.deepEqual(results, unique);
+        });
 
-    it('Should return right timestamp for a given date', async function() {
-        let block = await dater.getDate(new Date('2016-07-20T13:20:40Z'));
-        assert.equal(block.timestamp, 1469020840);
-    });
+        it('Should return right timestamp for a given date', async function () {
+            let block = await dater.getDate(new Date('2016-07-20T13:20:40Z'));
+            assert.equal(block.timestamp, 1469020840);
+        });
 
-    it('Should return right timestamp if given time is before first block time', async function() {
-        let block = await dater.getDate(new Date('1961-04-12T06:07:00Z'));
-        assert.equal(block.timestamp, 1438269988);
-    });
+        it('Should return right timestamp if given time is before first block time', async function () {
+            let block = await dater.getDate(new Date('1961-04-12T06:07:00Z'));
+            assert.equal(block.timestamp, 1438269988);
+        });
 
-    it('Should return right timestamp if given time is in the future', async function() {
-        let { timestamp } = await web3.eth.getBlock('latest');
-        let block = await dater.getDate(moment().add(100, 'years'), true, true);
-        assert.equal(block.timestamp, timestamp);
+        it('Should return right timestamp if given time is in the future', async function () {
+            let { timestamp } = await web3.eth.getBlock('latest');
+            let block = await dater.getDate(moment().add(100, 'years'), true, true);
+            assert.equal(block.timestamp, timestamp);
+        });
+        
+        it('Should return the right estimate timestamp if given block is in the future', async function () {
+            // let { timestamp } = await web3.eth.getBlock('latest');
+            // latest + overheadBlock = futureBlock
+            // calculated estimate date
+            let timestamp = await dater.getEstimateDate(20669502);
+            console.log("timestamp:", timestamp);
+            // let the block passing
+            // check diff between actual and estimate date
+            // assert.equal(block.timestamp, timestamp);
+        });
     });
-});
+};
+
+module.exports = { run };

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,0 +1,15 @@
+const ethersV5Test = require('./ethers-v5.test');
+const ethersTest = require('./ethers.test');
+const generalTest = require('./general.test');
+const specificTest = require('./specific.test');
+const viemTest = require('./viem.test');
+const web3v1Test = require('./web3-v1.test');
+
+describe('Test Suite', async function () {
+    ethersV5Test.run();
+    ethersTest.run();
+    generalTest.run();
+    specificTest.run();
+    viemTest.run();
+    web3v1Test.run();
+});

--- a/test/specific.test.js
+++ b/test/specific.test.js
@@ -7,51 +7,55 @@ require('dotenv').config();
 const web3 = new Web3(new Web3.providers.HttpProvider(process.env.PROVIDER));
 const dater = new ethDater(web3);
 
-describe('Block By Date Specific Dates Tests', function() {
-    this.timeout(0);
+const run = async () => {
+    describe('Block By Date Specific Dates Tests', function () {
+        this.timeout(0);
 
-    it('Should make less then 15 requests for 2015-09-03T08:47:03.168Z', async function() {
-        dater.requests = 0;
-        await dater.getDate('2015-09-03T08:47:03.168Z');
-        assert.isBelow(dater.requests, 15);
-    });
+        it('Should make less then 15 requests for 2015-09-03T08:47:03.168Z', async function () {
+            dater.requests = 0;
+            await dater.getDate('2015-09-03T08:47:03.168Z');
+            assert.isBelow(dater.requests, 15);
+        });
 
-    it('Should make less then 15 requests for 2017-09-09T16:33:13.236Z', async function() {
-        dater.requests = 0;
-        await dater.getDate('2017-09-09T16:33:13.236Z');
-        assert.isBelow(dater.requests, 15);
-    });
+        it('Should make less then 15 requests for 2017-09-09T16:33:13.236Z', async function () {
+            dater.requests = 0;
+            await dater.getDate('2017-09-09T16:33:13.236Z');
+            assert.isBelow(dater.requests, 15);
+        });
 
-    it('Should make less then 15 requests for 2017-09-22T13:52:59.961Z', async function() {
-        dater.requests = 0;
-        await dater.getDate('2017-09-22T13:52:59.961Z');
-        assert.isBelow(dater.requests, 15);
-    });
+        it('Should make less then 15 requests for 2017-09-22T13:52:59.961Z', async function () {
+            dater.requests = 0;
+            await dater.getDate('2017-09-22T13:52:59.961Z');
+            assert.isBelow(dater.requests, 15);
+        });
 
-    it('Should make less then 16 requests for 2016-11-14T14:46:06.107Z', async function() {
-        dater.requests = 0;
-        await dater.getDate('2016-11-14T14:46:06.107Z');
-        assert.isBelow(dater.requests, 15);
-    });
+        it('Should make less then 16 requests for 2016-11-14T14:46:06.107Z', async function () {
+            dater.requests = 0;
+            await dater.getDate('2016-11-14T14:46:06.107Z');
+            assert.isBelow(dater.requests, 15);
+        });
 
-    it('Should make less then 15 requests for 2017-04-20T07:54:29.965Z', async function() {
-        dater.requests = 0;
-        await dater.getDate('2017-04-20T07:54:29.965Z');
-        assert.isBelow(dater.requests, 15);
-    });
+        it('Should make less then 15 requests for 2017-04-20T07:54:29.965Z', async function () {
+            dater.requests = 0;
+            await dater.getDate('2017-04-20T07:54:29.965Z');
+            assert.isBelow(dater.requests, 15);
+        });
 
-    it('Should return right timestamp for a given date', async function() {
-        let block = await dater.getDate(moment('2015-07-30T11:28:01-04:00'));
-        assert.equal(block.block, 5);
-    });
+        it('Should return right timestamp for a given date', async function () {
+            let block = await dater.getDate(moment('2015-07-30T11:28:01-04:00'));
+            assert.equal(block.block, 5);
+        });
 
-    it('Should return right timestamp for a given date', async function() {
-        let block = await dater.getDate(moment('2015-07-30T11:28:02-04:00'));
-        assert.equal(block.block, 5);
-    });
+        it('Should return right timestamp for a given date', async function () {
+            let block = await dater.getDate(moment('2015-07-30T11:28:02-04:00'));
+            assert.equal(block.block, 5);
+        });
 
-    it('Should return right timestamp for a given date', async function() {
-        let block = await dater.getDate(moment('2015-07-30T11:28:03-04:00'));
-        assert.equal(block.block, 5);
+        it('Should return right timestamp for a given date', async function () {
+            let block = await dater.getDate(moment('2015-07-30T11:28:03-04:00'));
+            assert.equal(block.block, 5);
+        });
     });
-});
+};
+
+module.exports = { run };

--- a/test/viem.test.js
+++ b/test/viem.test.js
@@ -10,22 +10,26 @@ const client = createPublicClient({
 });
 const dater = new ethDater(client);
 
-describe('Block By Date Viem Tests', function() {
-    this.timeout(0);
+const run = async () => {
+    describe('Block By Date Viem Tests', function () {
+        this.timeout(0);
 
-    it('Should get right block for a given string', async function() {
-        let block = await dater.getDate('2016-07-20T13:20:40Z');
-        assert.equal(block.block, 1920000);
-    });
+        it('Should get right block for a given string', async function () {
+            let block = await dater.getDate('2016-07-20T13:20:40Z');
+            assert.equal(block.block, 1920000);
+        });
 
-    it('Should return 1 as block number if given time is before first block time', async function() {
-        let block = await dater.getDate(new Date('1961-04-12T06:07:00Z'));
-        assert.equal(block.block, 1);
-    });
+        it('Should return 1 as block number if given time is before first block time', async function () {
+            let block = await dater.getDate(new Date('1961-04-12T06:07:00Z'));
+            assert.equal(block.block, 1);
+        });
 
-    it('Should return last block number if given time is in the future', async function() {
-        let last = await client.getBlockNumber();
-        let block = await dater.getDate(moment().add(100, 'years'), true, true);
-        assert.equal(block.block, last);
+        it('Should return last block number if given time is in the future', async function () {
+            let last = await client.getBlockNumber();
+            let block = await dater.getDate(moment().add(100, 'years'), true, true);
+            assert.equal(block.block, last);
+        });
     });
-});
+};
+
+module.exports = { run };

--- a/test/web3-v1.test.js
+++ b/test/web3-v1.test.js
@@ -6,22 +6,26 @@ const ethDater = require('../lib/ethereum-block-by-date');
 const web3 = new Web3(new Web3.providers.HttpProvider(process.env.PROVIDER));
 const dater = new ethDater(web3);
 
-describe('Block By Date Web3@1 Tests', function() {
-    this.timeout(0);
+const run = async () => {
+    describe('Block By Date Web3@1 Tests', function () {
+        this.timeout(0);
 
-    it('Should get right block for a given string', async function() {
-        let block = await dater.getDate('2016-07-20T13:20:40Z');
-        assert.equal(block.block, 1920000);
-    });
+        it('Should get right block for a given string', async function () {
+            let block = await dater.getDate('2016-07-20T13:20:40Z');
+            assert.equal(block.block, 1920000);
+        });
 
-    it('Should return 1 as block number if given time is before first block time', async function() {
-        let block = await dater.getDate(new Date('1961-04-12T06:07:00Z'));
-        assert.equal(block.block, 1);
-    });
+        it('Should return 1 as block number if given time is before first block time', async function () {
+            let block = await dater.getDate(new Date('1961-04-12T06:07:00Z'));
+            assert.equal(block.block, 1);
+        });
 
-    it('Should return last block number if given time is in the future', async function() {
-        let last = await web3.eth.getBlockNumber();
-        let block = await dater.getDate(moment().add(100, 'years'), true, true);
-        assert.equal(block.block, last);
+        it('Should return last block number if given time is in the future', async function () {
+            let last = await web3.eth.getBlockNumber();
+            let block = await dater.getDate(moment().add(100, 'years'), true, true);
+            assert.equal(block.block, last);
+        });
     });
-});
+};
+
+module.exports = { run };


### PR DESCRIPTION
I am adding a feature for `getEstimateDate` form given block number.

Motivation
- For release or lock smart contracts that rely on block number, not the timestamp

Acceptance Criteria
- getEstimatedDate should not differ from the actual time stamp when the block is mined.
- should work on any EVM-based blockchain network 